### PR TITLE
fix: set version in pyproject.toml

### DIFF
--- a/iati_sphinx_theme/__init__.py
+++ b/iati_sphinx_theme/__init__.py
@@ -4,8 +4,6 @@ from os import path
 
 import sphinx.application
 
-__version__ = "0.0.0"
-
 
 def setup(app: sphinx.application.Sphinx) -> None:
     app.add_html_theme("iati_sphinx_theme", path.abspath(path.dirname(__file__)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,9 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "iati-sphinx-theme"
+version="0.0.0"
 readme = "README.md"
-dynamic = ["version", "description"]
+dynamic = ["description"]
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
Semantic-release requires version in pyproject.toml instead of the `__version__` attribute