### PR TITLE
fix: upgrade semantic-release-pypi to fix pypi publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "iati-design-system": "^1.2.0",
         "sass": "^1.75.0",
         "semantic-release": "^23.1.1",
-        "semantic-release-pypi": "^3.0.0"
+        "semantic-release-pypi": "^3.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7248,9 +7248,9 @@
       }
     },
     "node_modules/semantic-release-pypi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-pypi/-/semantic-release-pypi-3.0.0.tgz",
-      "integrity": "sha512-W4Eq1+Y8AKPZSO8I3LJXQ8vY288dl8xQ29sILLP/2MGYDc47rWpPV7aK8Baup/aj07qOHR9hDwD4AuI5u5gshw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/semantic-release-pypi/-/semantic-release-pypi-3.0.2.tgz",
+      "integrity": "sha512-NPuXYObaTBy89Hh9GfkgnZuXgXGBwfofpFm2sBMUSQVNudOuRaVqLNz6Qkei5yM+G+IJNTEbWid8jpY3hNBM/g==",
       "dev": true,
       "dependencies": {
         "execa": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "iati-design-system": "^1.2.0",
     "sass": "^1.75.0",
     "semantic-release": "^23.1.1",
-    "semantic-release-pypi": "^3.0.0"
+    "semantic-release-pypi": "^3.0.2"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
Upgrade `semantic-release-pypi` to fix publish error due to recent release of `importlib-metadata` (https://github.com/abichinger/semantic-release-pypi/commit/43a3c53275c4cf46493f36794be1f3b865df5c21)