### PR TITLE
fix: make link back to homepage stay on current language

### DIFF
--- a/iati_sphinx_theme/header.html
+++ b/iati_sphinx_theme/header.html
@@ -16,7 +16,7 @@
       </div>
       <ul>
           <li class="iati-mobile-nav__item">
-            <a href="/"  class="iati-mobile-nav__link">{{ _(project) }}</a>
+            <a href="{{ pathto('', 1) }}"  class="iati-mobile-nav__link">{{ _(project) }}</a>
           </li>
       </ul>
       <ul>
@@ -74,7 +74,7 @@
         <nav>
           <ul class="iati-tool-nav">
               <li>
-                <a href="/"  class="iati-tool-nav-link">{{ _(project) }}</a>
+                <a href="{{ pathto('', 1) }}"  class="iati-tool-nav-link">{{ _(project) }}</a>
               </li>
           </ul>
         </nav>


### PR DESCRIPTION
In the header, there is a link which goes back to the homepage of the documentation site. Previously this was only tested for a single language, so going back to `/` was fine. However, the way Read The Docs deploys multiple languages/versions is `my-domain.com/en/latest` so going back to `/` always takes the user back to the default language and the latest version, rather than the homepage for the language and version that they were on. This fixes that by using Sphinx's `pathto` function instead.