### PR TITLE
Navigation between tools and docs sites

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,8 @@ html_theme_options = {
     "languages": {
         "en": "English",
     },
+    "tool_name": "IATI Example Tool",
+    "tool_url": "https://example.com/",
 }
 
 todo_include_todos = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,9 @@ This theme has multiple options, which can be configured using the :code:`html_t
 
   html_theme_options = {
     "github_repository": "https://github.com/organisation/repository",
-    "plausible_domain": "example.com"
+    "plausible_domain": "example.com",
+    "tool_name": "IATI Tool",
+    "tool_url": "https://tool.iatistandard.org/",
   }
 
 There is more information on each option below.
@@ -59,3 +61,13 @@ For example, for the Sphinx site :code:`docs.example.com`, use :code:`example.co
   html_theme_options = {
     "plausible_domain": "example.com"
   }
+
+:code:`tool_name`
+-----------------
+
+The name of the tool which your Sphinx site documents.
+
+:code:`tool_url`
+----------------
+
+The URL of the tool which your Sphinx site documents.

--- a/iati_sphinx_theme/header.html
+++ b/iati_sphinx_theme/header.html
@@ -5,6 +5,13 @@
   {"text": "Contact", "link": "https://iatistandard.org/guidance/get-support/"},
 ] %}
 
+{% set tool_nav_items = [
+  {"text": theme_tool_name, "link": theme_tool_url},
+  {"text": project, "link": pathto('', 1)},
+] if theme_tool_name else [
+  {"text": project, "link": pathto('', 1)},
+]%}
+
 <div class="iati-mobile-nav js-iati-mobile-nav">
   <div class="iati-mobile-nav__overlay js-iati-mobile-overlay"></div>
     <nav class="iati-mobile-nav__menu">
@@ -15,9 +22,11 @@
         </button>
       </div>
       <ul>
+        {% for nav_item in tool_nav_items %}
           <li class="iati-mobile-nav__item">
-            <a href="{{ pathto('', 1) }}"  class="iati-mobile-nav__link">{{ _(project) }}</a>
+            <a href="{{ nav_item['link'] }}" class="iati-mobile-nav__link">{{ nav_item["text"] }}</a>
           </li>
+        {% endfor %}
       </ul>
       <ul>
         {% for nav_item in general_nav_items %}
@@ -73,9 +82,11 @@
       <div class="iati-header__nav">
         <nav>
           <ul class="iati-tool-nav">
+            {% for nav_item in tool_nav_items %}
               <li>
-                <a href="{{ pathto('', 1) }}"  class="iati-tool-nav-link">{{ _(project) }}</a>
+                <a href="{{ nav_item['link'] }}" class="iati-tool-nav-link">{{ nav_item["text"] }}</a>
               </li>
+            {% endfor %}
           </ul>
         </nav>
       </div>

--- a/iati_sphinx_theme/page.html
+++ b/iati_sphinx_theme/page.html
@@ -1,0 +1,32 @@
+{% extends "basic/page.html" %}
+
+{%- block body %}
+  <nav class="iati-breadcrumb">
+    {% if theme_tool_name %}
+      <span class="iati-breadcrumb__previous">
+        <i class="iati-icon iati-icon--chevron-left"></i>
+        <a href="#" class="iati-breadcrumb-link">{{ theme_tool_name }}</a>
+      </span>
+    {% endif %}
+    <ol class="iati-breadcrumb__list">
+      {% if theme_tool_name %}
+        <li class="iati-breadcrumb-item">
+          <a href="{{ theme_tool_url }}" class="iati-breadcrumb-link">
+            {{ theme_tool_name }}
+          </a>
+        </li>
+      {% endif %}
+      {% if (project != title) %}
+      <li class="iati-breadcrumb-item">
+        <a href="{{ pathto('', 1) }}"  class="iati-breadcrumb-link">{{ _(project) }}</a>
+      </li>
+      {% endif %}
+      {% if (project != title) or theme_tool_name %}
+        <li class="iati-breadcrumb-item iati-breadcrumb-item--current">
+          <a aria-current="page" class="iati-breadcrumb-link">{{ title }}</a>
+        </li>
+      {% endif %}
+    </ol>
+  </nav>
+  {{ super() }}
+{%- endblock %}

--- a/iati_sphinx_theme/theme.conf
+++ b/iati_sphinx_theme/theme.conf
@@ -9,3 +9,5 @@ globaltoc_maxdepth = 2
 show_relations = False
 plausible_domain =
 languages =
+tool_name =
+tool_url =


### PR DESCRIPTION
Improve ability to navigate back from documentation site to original tool
- Add a breadcrumb component in the format: `Tool / Docs / Page`, e.g. `IATI Validator / IATI Validator Docs / Categories`
- Add a link back to the tool in the navigation bar