### PR TITLE
More docs for theme translation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,7 @@ build:
       - npm run build
     pre_build:
       - make compile
+      - pybabel compile -d docs/locale --domain=iati-sphinx-theme
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,16 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+
+import sphinx.application
+from sphinx.locale import get_translation
+
+import iati_sphinx_theme
+
+MESSAGE_CATALOG_NAME = "iati-sphinx-theme"
+_ = get_translation(MESSAGE_CATALOG_NAME)
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
@@ -27,19 +37,27 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_theme = "iati_sphinx_theme"
 html_theme_options = {
     "github_repository": "https://github.com/IATI/sphinx-theme",
-    "header_title_text": "IATI Sphinx Theme",
+    "header_title_text": _("IATI Sphinx Theme"),
     "languages": {
         "en": "English",
         "fr": "Français",
         "es": "Español",
     },
     # Uncomment below lines to display tool navigation
-    # "tool_name": "IATI Example Tool",
-    # "tool_url": "https://example.com/",
+    "tool_name": _("IATI Example Tool"),
+    "tool_url": "https://example.com/",
 }
 
 todo_include_todos = True
 
 # -- Options for Texinfo output -------------------------------------------
 
-locale_dirs = ["locale/", "../iati_sphinx_theme/locale"]
+locale_dirs = [
+    "locale",
+    os.path.join(os.path.dirname(iati_sphinx_theme.__file__), "locale"),
+]
+
+
+def setup(app: sphinx.application.Sphinx) -> None:
+    locale_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "locale")
+    app.add_message_catalog(MESSAGE_CATALOG_NAME, locale_path)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,14 +93,29 @@ The URL of the tool which your Sphinx site documents.
 Translation
 ===========
 
-The IATI Sphinx Theme is translatable.
-
-Strings built into the theme will be translated automatically into supported languages.
-The following languages are currently supported:
+The IATI Sphinx Theme is translatable. The following languages are currently supported:
 
 - English (:code:`en`)
 - French  (:code:`fr`)
 - Spanish  (:code:`es`)
+
+Built-in strings
+----------------
+
+To enable translation of built-in strings, you must add the theme to the :code:`locale_dirs` list in your :code:`conf.py`.
+
+.. code-block:: python
+
+  import os
+  import iati_sphinx_theme
+
+  local_dirs = [
+    "locale",
+    os.path.join(os.path.dirname(iati_sphinx_theme.__file__), "locale")
+  ]
+
+User-defined strings
+--------------------
 
 User-defined strings must be translated by the user of the theme.
 These are configured in your :code:`conf.py` file under :code:`html_theme_options`.
@@ -118,6 +133,7 @@ In order to translate these, complete the following steps in the same location a
 
   html_theme_options = {
       "header_title_text": _("Title"),
+      "tool_name": _("IATI Example Tool"),
   }
 
   def setup(app):
@@ -140,4 +156,12 @@ In order to translate these, complete the following steps in the same location a
   # To update an existing language
   pybabel update -i locale/iati-sphinx-theme.pot -d locale --domain=iati-sphinx-theme -l es
 
-4. Continue with your project's usual translation workflow.
+4. Compile the :code:`.mo` files.
+   This must be done before Sphinx builds the project, for example using `Read the Docs' pre_build job <https://docs.readthedocs.io/en/stable/config-file/v2.html#build-jobs>`_,
+   or by compiling and committing the files to version control.
+
+.. code-block::
+
+  pybabel compile -d locale --domain=iati-sphinx-theme
+
+5. Continue with your project's usual translation workflow.

--- a/docs/locale/es/LC_MESSAGES/iati-sphinx-theme.po
+++ b/docs/locale/es/LC_MESSAGES/iati-sphinx-theme.po
@@ -1,0 +1,28 @@
+# Spanish translations for PROJECT.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-01-22 14:11+0200\n"
+"PO-Revision-Date: 2025-01-21 16:42+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.14.0\n"
+
+#: conf.py:39 conf.py:67
+msgid "IATI Sphinx Theme"
+msgstr "IATI Sphinx Theme Spanish"
+
+#: conf.py:46
+msgid "IATI Example Tool"
+msgstr "IATI Example Tool Spanish"
+

--- a/docs/locale/iati-sphinx-theme.pot
+++ b/docs/locale/iati-sphinx-theme.pot
@@ -1,0 +1,27 @@
+# Translations template for PROJECT.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-01-22 14:11+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.14.0\n"
+
+#: conf.py:39 conf.py:67
+msgid "IATI Sphinx Theme"
+msgstr ""
+
+#: conf.py:46
+msgid "IATI Example Tool"
+msgstr ""
+

--- a/iati_sphinx_theme/header.html
+++ b/iati_sphinx_theme/header.html
@@ -6,10 +6,10 @@
 ] %}
 
 {% set tool_nav_items = [
-  {"text": _(theme_tool_name), "link": theme_tool_url},
-  {"text": _(theme_header_title_text), "link": pathto('', 1)},
+  {"text": theme_tool_name, "link": theme_tool_url},
+  {"text": theme_header_title_text, "link": pathto('', 1)},
 ] if theme_tool_name else [
-  {"text": _(theme_header_title_text), "link": pathto('', 1)},
+  {"text": theme_header_title_text, "link": pathto('', 1)},
 ]%}
 
 <div class="iati-mobile-nav js-iati-mobile-nav">
@@ -76,7 +76,7 @@
 
       <div class="iati-header-title">
         <p class="iati-header-title__eyebrow">{{ _("IATI Tools") }}</p>
-        <p class="iati-header-title__heading">{{ _(theme_header_title_text) }}</p>
+        <p class="iati-header-title__heading">{{ theme_header_title_text }}</p>
       </div>
 
       <div class="iati-header__nav">


### PR DESCRIPTION
- Add more comprehensive docs for how to use the theme with translations
- Removed the unnecessary translation wrapper `_(...)` from `header.html` as these are already marked for translation in the `conf.py` file
- Added an example/fake Spanish translation as a working example of the build steps required