### PR TITLE
Create custom `iati-reference` role

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,22 @@ For example, for the Sphinx site :code:`docs.example.com`, use :code:`example.co
 Items to include in the header tool nav bar.
 Defaults to a single item that links back to the site's homepage.
 
+Custom roles
+============
+
+:code:`iati-reference`
+----------------------
+
+When referencing elements of the standard, use the :code:`iati-reference` role. For example:
+
+.. code-block:: rst
+
+  :iati-reference:`iati-activities/iati-activity/iati-identifier`
+
+The code above will apply the following styles:
+
+:iati-reference:`iati-activities/iati-activity/iati-identifier`
+
 Translation
 ===========
 

--- a/iati_sphinx_theme/__init__.py
+++ b/iati_sphinx_theme/__init__.py
@@ -2,14 +2,31 @@
 
 from datetime import datetime
 from os import path
+from typing import Any
 
 import sphinx.application
+from docutils import nodes
+from docutils.parsers.rst.states import Inliner
 
 SUPPORTED_LANGUAGES = {
     "en": "English",
     "fr": "Français",
     "es": "Español",
 }
+
+
+def iati_reference_role(
+    name: str,
+    rawtext: str,
+    text: str,
+    lineno: int,
+    inliner: Inliner,
+    options: dict[str, Any] = {},
+    content: list[Any] = [],
+) -> tuple[list[nodes.Node], list[Any]]:
+    node = nodes.inline(text=text)
+    node["classes"].append("iati-reference")
+    return [node], []
 
 
 def setup(app: sphinx.application.Sphinx) -> None:
@@ -27,3 +44,4 @@ def setup(app: sphinx.application.Sphinx) -> None:
     app.add_js_file("language-switcher.js")
     locale_path = path.join(path.abspath(path.dirname(__file__)), "locale")
     app.add_message_catalog("sphinx", locale_path)
+    app.add_role("iati-reference", iati_reference_role)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "sphinx-theme",
       "devDependencies": {
-        "iati-design-system": "^3.4.0",
+        "iati-design-system": "^3.12.0",
         "sass": "^1.75.0",
         "vite": "^5.4.11"
       }
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/iati-design-system": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/iati-design-system/-/iati-design-system-3.4.0.tgz",
-      "integrity": "sha512-oj+2ONk5lM8FOEhY53npurVUV2KS9xAUHsO3Id0J6pWl/x+U1i0Rk6XMPgkRGvmbVBF3gF6M5pskbwh745TWcw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/iati-design-system/-/iati-design-system-3.12.0.tgz",
+      "integrity": "sha512-hxwE2jT69sQleEEAJ+wyzn/4PUJVQzpeXKj82VtNF6U/UQ8AUGAtRS7NXZNBoeXDpsf94ZDD6gQvfQFO7DHnbA==",
       "dev": true,
       "dependencies": {
         "normalize-scss": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:watch": "npm run build -- --watch"
   },
   "devDependencies": {
-    "iati-design-system": "^3.4.0",
+    "iati-design-system": "^3.12.0",
     "sass": "^1.75.0",
     "vite": "^5.4.11"
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "iati-sphinx-theme"
-version="2.0.0"
+version="2.1.0"
 readme = "README.md"
 dynamic = ["description"]
 dependencies = []


### PR DESCRIPTION
Specific styling for referencing elements of the IATI Standard were recently added to the design system. This PR allows docs authors to apply that style in their `.rst` files with the use of a custom role `iati-reference`.

Example usage:
```rst
.. index.rst

Some documentation about the :iati-reference:`iati-activities/iati-activity/iati-identifier` element.
```