### PR TITLE
Use theme option instead of `project` in templates to enable translation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ _ = get_translation(MESSAGE_CATALOG_NAME)
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = str(_("IATI Sphinx Theme"))
+project = "IATI Sphinx Theme"
 author = "IATI Secretariat"
 language = "en"
 
@@ -38,6 +38,8 @@ html_theme = "iati_sphinx_theme"
 html_theme_options = {
     "github_repository": "https://github.com/IATI/sphinx-theme",
     "languages": ["en", "fr", "es"],
+    "project_title": _("IATI Sphinx Theme: Documentation"),
+    "header_title_text": _("IATI Sphinx Theme"),
 }
 
 todo_include_todos = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ This theme has multiple options, which can be configured using the :code:`html_t
     "header_eyebrow_text": "IATI Tools: Documentation",
     "languages": ["en", "fr", "es"],
     "plausible_domain": "example.com",
+    "project_title": "IATI Sphinx Theme: Documentation",
     "tool_nav_items": {
       "IATI Tool": "https://tool.iatistandard.org/"
     },
@@ -89,6 +90,11 @@ For example, for the Sphinx site :code:`docs.example.com`, use :code:`example.co
   html_theme_options = {
     "plausible_domain": "example.com"
   }
+
+:code:`project_title`
+---------------------
+
+The text to use in the breadcrumb and tool navigation components.
 
 :code:`tool_nav_items`
 ----------------------

--- a/docs/locale/es/LC_MESSAGES/iati-sphinx-theme.po
+++ b/docs/locale/es/LC_MESSAGES/iati-sphinx-theme.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-01-22 14:11+0200\n"
+"POT-Creation-Date: 2025-04-24 09:06+0300\n"
 "PO-Revision-Date: 2025-01-21 16:42+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: conf.py:39 conf.py:67
+#: conf.py:41
+msgid "IATI Sphinx Theme: Documentation"
+msgstr "IATI Sphinx Theme Spanish: Documentation"
+
+#: conf.py:42
 msgid "IATI Sphinx Theme"
 msgstr "IATI Sphinx Theme Spanish"
-
-#: conf.py:46
-msgid "IATI Example Tool"
-msgstr "IATI Example Tool Spanish"
 

--- a/docs/locale/iati-sphinx-theme.pot
+++ b/docs/locale/iati-sphinx-theme.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-01-22 14:11+0200\n"
+"POT-Creation-Date: 2025-04-24 09:06+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: conf.py:39 conf.py:67
-msgid "IATI Sphinx Theme"
+#: conf.py:41
+msgid "IATI Sphinx Theme: Documentation"
 msgstr ""
 
-#: conf.py:46
-msgid "IATI Example Tool"
+#: conf.py:42
+msgid "IATI Sphinx Theme"
 msgstr ""
 

--- a/iati_sphinx_theme/header.html
+++ b/iati_sphinx_theme/header.html
@@ -5,7 +5,7 @@
   _("Contact"): "https://iatistandard.org/guidance/get-support/",
  } %}
 
-{% set default_tool_nav_items = { project: pathto('', 1) } %}
+{% set default_tool_nav_items = { theme_project_title: pathto('', 1) } %}
 {% set tool_nav_items = theme_tool_nav_items or {} %}
 {% set noop = tool_nav_items.update(default_tool_nav_items) %}
 
@@ -73,7 +73,7 @@
 
       <div class="iati-header-title">
         <p class="iati-header-title__eyebrow">{{ theme_header_eyebrow_text or _("IATI Tools: Documentation") }} </p>
-        <p class="iati-header-title__heading">{{ theme_header_title_text or project }}</p>
+        <p class="iati-header-title__heading">{{ theme_header_title_text or theme_project_title }}</p>
       </div>
 
       <div class="iati-header__nav">

--- a/iati_sphinx_theme/page.html
+++ b/iati_sphinx_theme/page.html
@@ -4,11 +4,11 @@
   <nav class="iati-breadcrumb">
     <span class="iati-breadcrumb__previous">
       <i class="iati-icon iati-icon--chevron-left"></i>
-      <a href="{{ pathto('', 1) }}" class="iati-breadcrumb-link">{{ project }}</a>
+      <a href="{{ pathto('', 1) }}" class="iati-breadcrumb-link">{{ theme_project_title }}</a>
     </span>
     <ol class="iati-breadcrumb__list">
       <li class="iati-breadcrumb-item">
-        <a href="{{ pathto('', 1) }}"  class="iati-breadcrumb-link">{{ project }}</a>
+        <a href="{{ pathto('', 1) }}"  class="iati-breadcrumb-link">{{ theme_project_title }}</a>
       </li>
       <li class="iati-breadcrumb-item iati-breadcrumb-item--current">
         <a aria-current="page" class="iati-breadcrumb-link">{{ title }}</a>

--- a/iati_sphinx_theme/theme.conf
+++ b/iati_sphinx_theme/theme.conf
@@ -10,5 +10,6 @@ header_title_text =
 header_eyebrow_text =
 show_relations = False
 plausible_domain =
+project_title =
 languages =
 tool_nav_items =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "iati-sphinx-theme"
-version="2.2.1"
+version="3.0.0"
 readme = "README.md"
 dynamic = ["description"]
 dependencies = []


### PR DESCRIPTION
The config value `project` from `conf.py` cannot be localised using Sphinx's `get_translation` function (see https://github.com/sphinx-doc/sphinx/issues/1260). So adding a theme option `project_title` for this information which can then be translated and used within templates.